### PR TITLE
Feature/exit fullscreen

### DIFF
--- a/library/src/main/java/com/ravenfeld/easyvideoplayer/EasyVideoPlayer.java
+++ b/library/src/main/java/com/ravenfeld/easyvideoplayer/EasyVideoPlayer.java
@@ -552,6 +552,16 @@ public class EasyVideoPlayer extends FrameLayout implements FragmentCallback, IU
     }
 
     @Override
+    public void enterFullscreen() {
+        playerView.enterFullscreen();
+    }
+
+    @Override
+    public void exitFullscreen() {
+        playerView.exitFullscreen();
+    }
+
+    @Override
     public void release() {
         if (playerView != null) {
             playerView.release();

--- a/library/src/main/java/com/ravenfeld/easyvideoplayer/IUserMethods.java
+++ b/library/src/main/java/com/ravenfeld/easyvideoplayer/IUserMethods.java
@@ -123,4 +123,8 @@ public interface IUserMethods {
     void release();
 
     void setVideoSizeLoading(float videoSizeLoading);
+
+    void enterFullscreen();
+
+    void exitFullscreen();
 }

--- a/library/src/main/java/com/ravenfeld/easyvideoplayer/internal/PlayerView.java
+++ b/library/src/main/java/com/ravenfeld/easyvideoplayer/internal/PlayerView.java
@@ -799,6 +799,20 @@ public class PlayerView extends FrameLayout implements IUserMethods, TextureView
         invalidateActions();
     }
 
+    @Override
+    public void enterFullscreen() {
+        if (!isVideoOnly) {
+            onClick(mBtnFullScreen);
+        }
+    }
+
+    @Override
+    public void exitFullscreen() {
+        if (isVideoOnly) {
+            onClick(mBtnFullScreen);
+        }
+    }
+
     private void resetPlayer() {
         if (EasyVideoPlayerConfig.isDebug()) {
             Log.d(TAG, hashCode() + " resetPlayer: ");

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -25,6 +25,8 @@
         <activity android:name=".SimpleActivity"/>
         <activity android:name=".SimpleFragmentPlayerCreated"/>
         <activity android:name=".ScreenSlidePagerActivity"/>
+        <activity android:name=".EnterFullscreenByCodeActivity" />
+
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/ravenfeld/easyvideoplayersample/ChooseActivity.java
+++ b/sample/src/main/java/com/ravenfeld/easyvideoplayersample/ChooseActivity.java
@@ -31,6 +31,12 @@ public class ChooseActivity extends AppCompatActivity {
                 startActivity(new Intent(ChooseActivity.this, ScreenSlidePagerActivity.class));
             }
         });
+        findViewById(R.id.button4).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(ChooseActivity.this, EnterFullscreenByCodeActivity.class));
+            }
+        });
     }
 
 }

--- a/sample/src/main/java/com/ravenfeld/easyvideoplayersample/EnterFullscreenByCodeActivity.java
+++ b/sample/src/main/java/com/ravenfeld/easyvideoplayersample/EnterFullscreenByCodeActivity.java
@@ -1,0 +1,29 @@
+package com.ravenfeld.easyvideoplayersample;
+
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.ravenfeld.easyvideoplayer.EasyVideoPlayer;
+import com.ravenfeld.easyvideoplayer.EasyVideoPlayerConfig;
+
+public class EnterFullscreenByCodeActivity extends AppCompatActivity {
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EasyVideoPlayerConfig.setDebug(true);
+        setContentView(R.layout.activity_fullscreen_by_code);
+
+        findViewById(R.id.enterFullscreenBtn).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                ((EasyVideoPlayer) findViewById(R.id.toggleBunny)).enterFullscreen();
+            }
+        });
+    }
+
+
+}

--- a/sample/src/main/res/layout/activity_fullscreen_by_code.xml
+++ b/sample/src/main/res/layout/activity_fullscreen_by_code.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/holo_blue_bright"
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/enterFullscreenBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Toggle Fullscreen" />
+
+        <com.ravenfeld.easyvideoplayer.EasyVideoPlayer
+            android:id="@+id/toggleBunny"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:enableSeekBar="true"
+            app:leftAction="none"
+            app:rightAction="none"
+            app:source="asset://big_buck_bunny.mp4"
+            app:startFullscreen="false" />
+
+    </LinearLayout>
+</ScrollView>

--- a/sample/src/main/res/layout/choose_activity.xml
+++ b/sample/src/main/res/layout/choose_activity.xml
@@ -23,4 +23,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Slide"/>
+
+    <Button
+        android:id="@+id/button4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Toggle Fullscreen by code" />
+
 </LinearLayout>


### PR DESCRIPTION
Changes aiming at adding the ability to enter or exit Fullscreen state by code. 
The methods enterFullscreen and exitFullscreen are using the `isVideoOnly` boolean to check if the player should change state. 
This same boolean is already used internally to toggle Fullscreen state when the native button is clicked.